### PR TITLE
Fix getRecentTracks function.

### DIFF
--- a/lib/user.js
+++ b/lib/user.js
@@ -78,7 +78,7 @@ User.prototype.getRecentStations = function (params, callback) {
 };
 
 User.prototype.getRecentTracks = function (user, callback) {
-	var options = defaults.defaultOptions(params, callback, 'recenttracks');
+	var options = defaults.defaultOptions({ 'user' : user }, callback, 'recenttracks');
 	this.lastfm.api.request('user.getRecentTracks', options);
 };
 


### PR DESCRIPTION
When calling getRecentTracks like this: 

``` js
lfm.user.getRecentTracks("aliouftw", function(err, tracks) {
  console.log("Tracks: " + tracks);
});
```

You get the following error:

``` js
$ node app.js 

/home/alioudiallo/src/webapps/music-test/node_modules/lastfmapi/lib/user.js:81
    var options = defaults.defaultOptions(params, callback, 'recenttracks');
                                          ^
ReferenceError: params is not defined
    at User.getRecentTracks (/home/alioudiallo/src/webapps/music-test/node_modules/lastfmapi/lib/user.js:81:40)
    at Object.<anonymous> (/home/alioudiallo/src/webapps/music-test/app.js:18:10)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:901:3
```

This pull request fixes this error.
