### PR TITLE
Make the getRecentTracks function take full parameters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,9 +687,9 @@ See [docs](http://www.last.fm/api/show/user.getPlaylists).
 
 See [docs](http://www.last.fm/api/show/user.getRecentStations) for params.
 
-##### `lfm.user.getRecentTracks(user, callback(err, recentTracks))`
+##### `lfm.user.getRecentTracks(params, callback(err, recentTracks))`
 
-See [docs](http://www.last.fm/api/show/user.getRecentTracks).
+See [docs](http://www.last.fm/api/show/user.getRecentTracks) for params.
 
 ##### `lfm.user.getRecommendedArtists(params, callback(err, recommendations))`
 

--- a/lib/user.js
+++ b/lib/user.js
@@ -77,8 +77,8 @@ User.prototype.getRecentStations = function (params, callback) {
 	this.lastfm.api.request('user.getRecentStations', options);
 };
 
-User.prototype.getRecentTracks = function (user, callback) {
-	var options = defaults.defaultOptions({ 'user' : user }, callback, 'recenttracks');
+User.prototype.getRecentTracks = function (params, callback) {
+	var options = defaults.defaultOptions(params, callback, 'recenttracks');
 	this.lastfm.api.request('user.getRecentTracks', options);
 };
 


### PR DESCRIPTION
Make the `getRecentTracks` take an object with the parameters specified in the [API](http://www.last.fm/api/show/user.getRecentTracks).
