### PR TITLE
Update event.js

### DIFF
--- a/lib/event.js
+++ b/lib/event.js
@@ -28,6 +28,12 @@ Event.prototype.getShouts = function (params, callback) {
 	this.lastfm.api.request('event.getShouts', options);
 };
 
+// Undocumented API call
+Event.prototype.search = function (params, callback) {
+	var options = defaults.defaultOptions(params, callback, 'results');
+	this.lastfm.api.request('event.search', options);
+};
+
 Event.prototype.share = function (params, callback) {
 	if (!Array.isArray(params.recipient)) { params.recipient = [ params.recipient ]; }
 	params.recipient = params.recipient.join(',');
@@ -44,3 +50,5 @@ Event.prototype.shout = function (eventId, message, callback) {
 	}, callback);
 	this.lastfm.api.request('event.shout', options);
 };
+
+


### PR DESCRIPTION
Hi,

I've been using your node module to connect to the Last.FM API, but I needed to do a search for festivals by name, which isn't described in the official documentation, but seems to exist nevertheless (at 'event.search', similar to 'artist.search'). Therefore, I've added this extra function to your module to be able to call this specific API function. I've pretty much copy-pasted it from artist.js, so not a lot of added magic here. Just thought it would be useful to also support this call.

Gr, Jiri