### PR TITLE
Fix redirects for https callback urls.

### DIFF
--- a/lib/lastfmapi.js
+++ b/lib/lastfmapi.js
@@ -42,7 +42,7 @@ var LastfmAPI = module.exports = function (options) {
 
 LastfmAPI.prototype.getAuthenticationUrl = function (params) {
 	if (!params) params = {};
-	var baseUrl = 'http://www.last.fm/api/auth/',
+	var baseUrl = 'http://www.last.fm/api/auth',
 	    urlParts = url.parse(baseUrl);
 
 	urlParts.query = {};;


### PR DESCRIPTION
As per [this issue](http://www.last.fm/forum/21713/_/2235684), last.fm has a double-urlescaping issue when the callback URL is using HTTPS.  Why they allow OAuth _without_ HTTPS is beyond me, but this applies the workaround outlined in the aforementioned thread.

We're using this for [soundtrack.io](https://soundtrack.io), which is now HTTPS-only (enforced through HSTS).

**Aside:** it's amusing that I can imagine _exactly_ what the code that implements this bug looks like.